### PR TITLE
Fix issue when panel is undefined

### DIFF
--- a/projects/ng-mat-select-infinite-scroll/src/lib/mat-select-infinite-scroll.directive.ts
+++ b/projects/ng-mat-select-infinite-scroll/src/lib/mat-select-infinite-scroll.directive.ts
@@ -79,6 +79,9 @@ export class MatSelectInfiniteScrollDirective implements OnInit, OnDestroy, Afte
   }
 
   getSelectItemHeightPx(): number {
+    if (!this.matSelect.panel) {
+      return;
+    }
     return parseFloat(getComputedStyle(this.matSelect.panel.nativeElement).fontSize) * SELECT_ITEM_HEIGHT_EM;
   }
 


### PR DESCRIPTION
I faced with problem, when I try to select item i get this error

core.js:1673 ERROR TypeError: Cannot read property 'nativeElement' of undefined
    at MatSelectInfiniteScrollDirective.push../node_modules/ng-mat-select-infinite-scroll/fesm5/ng-mat-select-infinite-scroll.js.MatSelectInfiniteScrollDirective.getSelectItemHeightPx (ng-mat-select-infinite-scroll.js:127)
    at MatSelectInfiniteScrollDirective.push../node_modules/ng-mat-select-infinite-scroll/fesm5/ng-mat-select-infinite-scroll.js.MatSelectInfiniteScrollDirective.handleScrollEvent (ng-mat-select-infinite-scroll.js:107)