### PR TITLE
Prevent dupe firing of infiniteScroll handler...

### DIFF
--- a/projects/ng-mat-select-infinite-scroll/src/lib/mat-select-infinite-scroll.directive.ts
+++ b/projects/ng-mat-select-infinite-scroll/src/lib/mat-select-infinite-scroll.directive.ts
@@ -1,6 +1,6 @@
 import {AfterViewInit, Directive, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
 import {MatSelect, SELECT_ITEM_HEIGHT_EM} from '@angular/material';
-import {auditTime, takeUntil, tap} from 'rxjs/operators';
+import {takeUntil, tap, debounceTime} from 'rxjs/operators';
 import {fromEvent, Subject, Subscription} from 'rxjs';
 
 @Directive({
@@ -9,6 +9,7 @@ import {fromEvent, Subject, Subscription} from 'rxjs';
 export class MatSelectInfiniteScrollDirective implements OnInit, OnDestroy, AfterViewInit {
 
   @Input() threshold = '15%';
+  @Input() debounceTime = 500;
   @Input() complete: boolean;
   @Output() infiniteScroll = new EventEmitter<void>();
 
@@ -55,7 +56,7 @@ export class MatSelectInfiniteScrollDirective implements OnInit, OnDestroy, Afte
   registerScrollListener() {
     this.scrollSubscription = fromEvent(this.panel, 'scroll').pipe(
       takeUntil(this.onDestroy),
-      // auditTime(300),
+      debounceTime(this.debounceTime),
       tap((event) => {
         this.handleScrollEvent(event);
       })


### PR DESCRIPTION
...while scrolling within the threshold before the infiniteScroll
handler completes any async process.

We were trying to use ng-mat-select-infinte-scroll to fetch large datasets and I noticed that during scrolling, the (infiniteScroll) handler was being called multiple times.  My hunch was that multiple scrolling events were being fired on the native element, and this seems to have fixed it.

I tested the fix on the transpiled JS in my project's node_modules because I couldn't get this project to build/bundle/test according to the directions.