### PR TITLE
deeply import with material for specific component

### DIFF
--- a/projects/example/src/app/app.module.ts
+++ b/projects/example/src/app/app.module.ts
@@ -3,7 +3,8 @@ import {NgModule} from '@angular/core';
 
 import {AppComponent} from './app.component';
 import {MatSelectInfiniteScrollModule} from 'ng-mat-select-infinite-scroll';
-import {MatFormFieldModule, MatSelectModule} from '@angular/material';
+import {MatFormFieldModule} from '@angular/material/form';
+import {MatSelectModule} from '@angular/material/select';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {FormsModule} from '@angular/forms';
 

--- a/projects/ng-mat-select-infinite-scroll/src/lib/mat-select-infinite-scroll.directive.ts
+++ b/projects/ng-mat-select-infinite-scroll/src/lib/mat-select-infinite-scroll.directive.ts
@@ -1,5 +1,5 @@
 import {AfterViewInit, Directive, EventEmitter, Input, NgZone, OnDestroy, OnInit, Output} from '@angular/core';
-import {MatSelect, SELECT_ITEM_HEIGHT_EM} from '@angular/material';
+import {MatSelect, SELECT_ITEM_HEIGHT_EM} from '@angular/material/select';
 import {debounceTime, takeUntil, tap} from 'rxjs/operators';
 import {fromEvent, Subject} from 'rxjs';
 


### PR DESCRIPTION
According to the angular upgrade guide it states:

Instead of importing from @angular/material, you should import deeply from the specific component. E.g. @angular/material/button. ng update will do this automatically for you.

This is causing an error when trying to update to angular 9

```
ERROR in ../../node_modules/ng-mat-select-infinite-scroll/lib/mat-select-infinite-scroll.directive.d.ts:2:27 - error TS2306: File '/node_modules/@angular/material/index.d.ts' is not a module.

2 import { MatSelect } from '@angular/material';
```
