### PR TITLE
`delay(0)` after `openedChange` to wait for panel to be available

### DIFF
--- a/projects/ng-mat-select-infinite-scroll/src/lib/mat-select-infinite-scroll.directive.ts
+++ b/projects/ng-mat-select-infinite-scroll/src/lib/mat-select-infinite-scroll.directive.ts
@@ -1,6 +1,6 @@
 import {AfterViewInit, Directive, EventEmitter, Input, NgZone, OnDestroy, OnInit, Output} from '@angular/core';
 import {MatSelect} from '@angular/material/select';
-import {takeUntil} from 'rxjs/operators';
+import {delay, takeUntil} from 'rxjs/operators';
 import {InfiniteScrollService} from "./infinite-scroll.service";
 import {Subject} from "rxjs";
 
@@ -26,6 +26,7 @@ export class MatSelectInfiniteScrollDirective implements OnDestroy, AfterViewIni
 
     ngAfterViewInit() {
         this.matSelect.openedChange.pipe(
+            delay(0),
             takeUntil(this.destroyed$)
         ).subscribe((opened) => {
             if (opened) {

--- a/projects/ng-mat-select-infinite-scroll/src/lib/mat-select-infinite-scroll.directive.ts
+++ b/projects/ng-mat-select-infinite-scroll/src/lib/mat-select-infinite-scroll.directive.ts
@@ -26,6 +26,7 @@ export class MatSelectInfiniteScrollDirective implements OnDestroy, AfterViewIni
 
     ngAfterViewInit() {
         this.matSelect.openedChange.pipe(
+            //Wait for the panel to be rendered (https://github.com/angular/components/issues/30596)
             delay(0),
             takeUntil(this.destroyed$)
         ).subscribe((opened) => {


### PR DESCRIPTION
This fixes https://github.com/HaidarZ/ng-mat-select-infinite-scroll/issues/57. Due to the Angular team this is the control's new behavior (https://github.com/angular/components/issues/30596).