### PR TITLE
Fix: Only `handleScrollEvent`, if `target` (container) still exists

### DIFF
--- a/projects/ng-mat-select-infinite-scroll/src/lib/infinite-scroll.service.ts
+++ b/projects/ng-mat-select-infinite-scroll/src/lib/infinite-scroll.service.ts
@@ -53,16 +53,17 @@ export class InfiniteScrollService {
         ).subscribe();
     }
 
-    handleScrollEvent(event: any, infiniteScrollCallback: () => void) {
+    handleScrollEvent(event: Event, infiniteScrollCallback: () => void) {
+        if (this.complete || !event.target) {
+            return;
+        }
+
         this.ngZone.runOutsideAngular(() => {
-            if (this.complete) {
-                return;
-            }
             const countOfRenderedOptions = Math.round(this.panel.scrollHeight / this.selectItemHeightPx);
             const infiniteScrollDistance = this.selectItemHeightPx * countOfRenderedOptions;
             const threshold = this.thrPc !== 0 ? (infiniteScrollDistance * this.thrPc) : this.thrPx;
 
-            const scrolledDistance = this.panel.clientHeight + event.target.scrollTop;
+            const scrolledDistance = this.panel.clientHeight + (event.target as HTMLElement).scrollTop;
 
             if ((scrolledDistance + threshold) >= infiniteScrollDistance) {
                 this.ngZone.run(infiniteScrollCallback);


### PR DESCRIPTION
If the last, **partially hidden** element of the control gets clicked, the element is selected and the container closes. Never the less a scroll event gets invoked but the `target` is null. This crashes the distance check.

This PR ensures that the container still exists. If not, the event would be irrelevant anyway. Furthermore the `complete` check is moved outside `this.ngZone.runOutsideAngular`.


Just out of curiosity: why is this code even invoked outside ng's zone?

Merge + Publish would be pretty welcome! 😊